### PR TITLE
fix: パッケージの構造が意図していないものだったため、src/main/java/com/codestep直下に/TODOappを追加…

### DIFF
--- a/src/main/java/com/codestep/TODOapp/TODOappApplication.java
+++ b/src/main/java/com/codestep/TODOapp/TODOappApplication.java
@@ -1,13 +1,13 @@
-package com.codestep;
+package com.codestep.TODOapp;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class TodOappApplication {
+public class TODOappApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(TodOappApplication.class, args);
+		SpringApplication.run(TODOappApplication.class, args);
 	}
 
 }


### PR DESCRIPTION
…し、アプリケーションクラスをそこへ移動。また、アプリケーションクラス名のTypoを修正した。